### PR TITLE
Fix Macro Selection Logic Deadlock

### DIFF
--- a/g13-config-tool/src/main/java/com/booker/g13/MacroEditorPanel.java
+++ b/g13-config-tool/src/main/java/com/booker/g13/MacroEditorPanel.java
@@ -191,7 +191,7 @@ public class MacroEditorPanel extends JPanel {
      * @param enabled The desired enabled state.
      */
     private void setComponentStates(boolean enabled) {
-        final JComponent[] components = { macroSelectionBox, macroList, nameText, addDelayButton, captureDelays, editButton, deleteButton };
+        final JComponent[] components = { macroList, nameText, addDelayButton, captureDelays, editButton, deleteButton };
         for (JComponent c : components) {
             c.setEnabled(enabled);
         }


### PR DESCRIPTION
This PR removes the macroSelectionBox element from setComponentStates so it's no longer impossible to select a non-default macro to enable the rest of the macro panel components.