### PR TITLE
Driver: mouse emulation, stick mouse mode, combo bindings, and robustness fixes

### DIFF
--- a/g13-driver/src/cpp/ComboPassThroughAction.cpp
+++ b/g13-driver/src/cpp/ComboPassThroughAction.cpp
@@ -1,0 +1,27 @@
+#include <linux/uinput.h>
+
+#include "ComboPassThroughAction.h"
+#include "Output.h"
+
+ComboPassThroughAction::ComboPassThroughAction(const std::vector<int>& codes) {
+	this->keycodes = codes;
+}
+
+ComboPassThroughAction::~ComboPassThroughAction() {
+}
+
+void ComboPassThroughAction::key_down() {
+	// Press in listed order (modifiers are written first in the binding).
+	for (int code : this->keycodes) {
+		UInput::send_event(EV_KEY, code, 1);
+		UInput::send_event(0, 0, 0); // SYN_REPORT
+	}
+}
+
+void ComboPassThroughAction::key_up() {
+	// Release in reverse order so modifiers come up last.
+	for (auto it = this->keycodes.rbegin(); it != this->keycodes.rend(); ++it) {
+		UInput::send_event(EV_KEY, *it, 0);
+		UInput::send_event(0, 0, 0); // SYN_REPORT
+	}
+}

--- a/g13-driver/src/cpp/ComboPassThroughAction.h
+++ b/g13-driver/src/cpp/ComboPassThroughAction.h
@@ -1,0 +1,26 @@
+#ifndef __COMBO_PASS_THROUGH_ACTION_H__
+#define __COMBO_PASS_THROUGH_ACTION_H__
+
+#include <vector>
+#include "G13Action.h"
+
+/**
+ * @class ComboPassThroughAction
+ * @brief Passthrough for a key combo (e.g. Ctrl+C). While the G-key is held,
+ * every code in the list is held down (pressed in listed order, released in
+ * reverse), so key repeat behaves like holding the real chord.
+ */
+class ComboPassThroughAction : public G13Action {
+private:
+	std::vector<int> keycodes;
+
+protected:
+	void key_down() override;
+	void key_up() override;
+
+public:
+	ComboPassThroughAction(const std::vector<int>& codes);
+	virtual ~ComboPassThroughAction();
+};
+
+#endif

--- a/g13-driver/src/cpp/Constants.h
+++ b/g13-driver/src/cpp/Constants.h
@@ -19,7 +19,7 @@
 enum stick_mode_t {
     STICK_KEYS = 0,   // Joystick movement emulates key presses (e.g., W, A, S, D).
     STICK_ABSOLUTE,   // Joystick provides absolute position values (like a gamepad).
-    /*STICK_RELATIVE,*/ // A possible future mode for relative mouse movement.
+    STICK_MOUSE,      // Joystick emits relative mouse motion with optional held keys/buttons.
 };
 
 /**

--- a/g13-driver/src/cpp/G13.cpp
+++ b/g13-driver/src/cpp/G13.cpp
@@ -47,6 +47,9 @@ G13::G13(libusb_device *device) {
     this->stick_engaged = false;
     this->stick_last_x = 128;
     this->stick_last_y = 128;
+    this->stick_center_x = 128;
+    this->stick_center_y = 128;
+    this->stick_centered = false;
     this->last_config_mtime = 0;
 
     actions.resize(G13_NUM_KEYS);
@@ -385,6 +388,15 @@ void G13::parse_joystick(unsigned char *buf) {
     stick_last_x = stick_x;
     stick_last_y = stick_y;
 
+    // The stick rarely rests at exactly (128,128); treat the first report's
+    // position as the neutral point so mouse mode doesn't drift.
+    if (!stick_centered) {
+        stick_center_x = stick_x;
+        stick_center_y = stick_y;
+        stick_centered = true;
+        syslog(LOG_INFO, "Stick neutral calibrated at (%d,%d)", stick_x, stick_y);
+    }
+
     if (stick_mode == STICK_MOUSE) {
         return; // Motion is emitted by stick_mouse_tick() from the main loop.
     }
@@ -412,9 +424,11 @@ void G13::parse_joystick(unsigned char *buf) {
 void G13::stick_mouse_tick() {
     if (stick_mode != STICK_MOUSE) return;
 
+    if (!stick_centered) return;
+
     const int DEAD_ZONE = 15;
-    int dx = stick_last_x - 128;
-    int dy = stick_last_y - 128;
+    int dx = stick_last_x - stick_center_x;
+    int dy = stick_last_y - stick_center_y;
 
     if (abs(dx) <= DEAD_ZONE && abs(dy) <= DEAD_ZONE) {
         stick_mouse_disengage();

--- a/g13-driver/src/cpp/G13.cpp
+++ b/g13-driver/src/cpp/G13.cpp
@@ -50,6 +50,8 @@ G13::G13(libusb_device *device) {
     this->stick_center_x = 128;
     this->stick_center_y = 128;
     this->stick_centered = false;
+    this->stick_acc_x = 0;
+    this->stick_acc_y = 0;
     this->last_config_mtime = 0;
 
     actions.resize(G13_NUM_KEYS);
@@ -443,8 +445,14 @@ void G13::stick_mouse_tick() {
         stick_engaged = true;
     }
 
-    int rel_x = (dx * stick_speed) / 64;
-    int rel_y = (dy * stick_speed) / 64;
+    // Carry the sub-pixel remainder between ticks so low speeds produce
+    // slow smooth motion instead of nothing until ~full deflection.
+    int sum_x = dx * stick_speed + stick_acc_x;
+    int sum_y = dy * stick_speed + stick_acc_y;
+    int rel_x = sum_x / 64;
+    int rel_y = sum_y / 64;
+    stick_acc_x = sum_x % 64;
+    stick_acc_y = sum_y % 64;
     if (rel_x == 0 && rel_y == 0) return;
 
     UInput::send_event(EV_REL, REL_X, rel_x);
@@ -459,6 +467,8 @@ void G13::stick_mouse_disengage() {
     }
     UInput::send_event(EV_SYN, SYN_REPORT, 0);
     stick_engaged = false;
+    stick_acc_x = 0;
+    stick_acc_y = 0;
 }
 
 void G13::parse_key(int key, unsigned char *byte) {

--- a/g13-driver/src/cpp/G13.cpp
+++ b/g13-driver/src/cpp/G13.cpp
@@ -22,6 +22,7 @@
 #include "G13Action.h"
 #include "PassThroughAction.h"
 #include "MacroAction.h"
+#include "MouseMoveAction.h"
 #include "Output.h"
 #include "Font.h"
 #include "ConfigPath.h" // NEW: Include Helper
@@ -201,6 +202,19 @@ void G13::parse_bindings_from_stream(std::istream& stream) {
                             actions[gKey] = std::make_unique<MacroAction>(macro->getSequence());
                             static_cast<MacroAction*>(actions[gKey].get())->setRepeats(repeats);
                         }
+                    }
+                }
+                else if (type == "mp") {
+                    std::string dx_str, dy_str, hold_str;
+                    if (!std::getline(ss, dx_str, ',') || !std::getline(ss, dy_str, ',')) continue;
+                    int mdx = std::stoi(trim_string(dx_str));
+                    int mdy = std::stoi(trim_string(dy_str));
+                    std::vector<int> hold = {BTN_MIDDLE};
+                    if (std::getline(ss, hold_str, ',')) {
+                        hold = parse_plus_list(trim_string(hold_str));
+                    }
+                    if (gKey >= 0 && gKey < G13_NUM_KEYS) {
+                        actions[gKey] = std::make_unique<MouseMoveAction>(mdx, mdy, hold);
                     }
                 }
             } catch (...) {}

--- a/g13-driver/src/cpp/G13.cpp
+++ b/g13-driver/src/cpp/G13.cpp
@@ -43,6 +43,10 @@ G13::G13(libusb_device *device) {
     this->loaded = 0;
     this->bindings = 0;
     this->stick_mode = STICK_KEYS;
+    this->stick_speed = 8;
+    this->stick_engaged = false;
+    this->stick_last_x = 128;
+    this->stick_last_y = 128;
     this->last_config_mtime = 0;
 
     actions.resize(G13_NUM_KEYS);
@@ -95,6 +99,7 @@ void G13::start() {
     while (keepGoing && daemon_keep_running) {
         check_for_config_update();
         check_fifo();
+        stick_mouse_tick();
 
         if (read() == -4) {
             break; 
@@ -171,6 +176,22 @@ void G13::parse_bindings_from_stream(std::istream& stream) {
                 if (r <= 255 && g <= 255 && b <= 255) setColor(r, g, b);
             }
         }
+        else if (key == "stick_mode") {
+            if (value == "mouse") stick_mode = STICK_MOUSE;
+            else if (value == "keys") stick_mode = STICK_KEYS;
+            else syslog(LOG_WARNING, "Unknown stick_mode '%s', keeping keys mode", value.c_str());
+        }
+        else if (key == "stick_speed") {
+            try { stick_speed = std::stoi(value); } catch (...) {
+                syslog(LOG_WARNING, "Invalid stick_speed '%s'", value.c_str());
+            }
+        }
+        else if (key == "stick_hold") {
+            stick_hold = parse_plus_list(value);
+        }
+        else if (key == "name") {
+            profile_name = value;
+        }
         else if (!key.empty() && key.rfind("G", 0) == 0) {
             try {
                 int gKey = std::stoi(key.substr(1));
@@ -223,6 +244,12 @@ void G13::parse_bindings_from_stream(std::istream& stream) {
 }
 
 void G13::loadBindings() {
+    stick_mouse_disengage();
+    stick_mode = STICK_KEYS;
+    stick_speed = 8;
+    stick_hold.clear();
+    profile_name.clear();
+
     // NEW: Use ConfigPath helper
     std::string filename = ConfigPath::getBindingPath(bindings);
 
@@ -306,7 +333,8 @@ int G13::read() {
     // (Existing read implementation)
     unsigned char buffer[G13_REPORT_SIZE];
     int size;
-    int error = libusb_interrupt_transfer(handle, LIBUSB_ENDPOINT_IN | G13_KEY_ENDPOINT, buffer, G13_REPORT_SIZE, &size, 100);
+    int timeout_ms = (stick_mode == STICK_MOUSE) ? 10 : 100;
+    int error = libusb_interrupt_transfer(handle, LIBUSB_ENDPOINT_IN | G13_KEY_ENDPOINT, buffer, G13_REPORT_SIZE, &size, timeout_ms);
 
     if (error == LIBUSB_ERROR_NO_DEVICE) {
         syslog(LOG_ERR, "G13 device disconnected.");
@@ -331,6 +359,13 @@ void G13::parse_joystick(unsigned char *buf) {
     int stick_x = buf[1];
     int stick_y = buf[2];
 
+    stick_last_x = stick_x;
+    stick_last_y = stick_y;
+
+    if (stick_mode == STICK_MOUSE) {
+        return; // Motion is emitted by stick_mouse_tick() from the main loop.
+    }
+
     if (stick_mode == STICK_ABSOLUTE) {
         UInput::send_event(EV_ABS, ABS_X, stick_x);
         UInput::send_event(EV_ABS, ABS_Y, stick_y);
@@ -349,6 +384,44 @@ void G13::parse_joystick(unsigned char *buf) {
             if (actions[codes[i]]) actions[codes[i]]->set(pressed[i]);
         }
     }
+}
+
+void G13::stick_mouse_tick() {
+    if (stick_mode != STICK_MOUSE) return;
+
+    const int DEAD_ZONE = 15;
+    int dx = stick_last_x - 128;
+    int dy = stick_last_y - 128;
+
+    if (abs(dx) <= DEAD_ZONE && abs(dy) <= DEAD_ZONE) {
+        stick_mouse_disengage();
+        return;
+    }
+
+    if (!stick_engaged) {
+        for (int code : stick_hold) {
+            UInput::send_event(EV_KEY, code, 1);
+        }
+        UInput::send_event(EV_SYN, SYN_REPORT, 0);
+        stick_engaged = true;
+    }
+
+    int rel_x = (dx * stick_speed) / 64;
+    int rel_y = (dy * stick_speed) / 64;
+    if (rel_x == 0 && rel_y == 0) return;
+
+    UInput::send_event(EV_REL, REL_X, rel_x);
+    UInput::send_event(EV_REL, REL_Y, rel_y);
+    UInput::send_event(EV_SYN, SYN_REPORT, 0);
+}
+
+void G13::stick_mouse_disengage() {
+    if (!stick_engaged) return;
+    for (auto it = stick_hold.rbegin(); it != stick_hold.rend(); ++it) {
+        UInput::send_event(EV_KEY, *it, 0);
+    }
+    UInput::send_event(EV_SYN, SYN_REPORT, 0);
+    stick_engaged = false;
 }
 
 void G13::parse_key(int key, unsigned char *byte) {

--- a/g13-driver/src/cpp/G13.cpp
+++ b/g13-driver/src/cpp/G13.cpp
@@ -333,6 +333,18 @@ G20=p,k.50
         write_text(2, 28, profile_name);
         write_lcd();
     }
+
+    // Publish the active softkey number so external tools (e.g. the LCD
+    // monitor) can display which profile is loaded.
+    std::string runtime_dir = std::getenv("XDG_RUNTIME_DIR") ? std::getenv("XDG_RUNTIME_DIR") : "/tmp";
+    std::string profile_state_path = runtime_dir + "/g13-profile";
+    std::ofstream profile_state_file(profile_state_path, std::ios::trunc);
+    if (profile_state_file.is_open()) {
+        profile_state_file << (this->bindings + 1);
+        profile_state_file.close();
+    } else {
+        syslog(LOG_WARNING, "Could not write profile state file: %s", profile_state_path.c_str());
+    }
 }
 
 void G13::setColor(int red, int green, int blue) {

--- a/g13-driver/src/cpp/G13.cpp
+++ b/g13-driver/src/cpp/G13.cpp
@@ -21,6 +21,7 @@
 #include "G13.h"
 #include "G13Action.h"
 #include "PassThroughAction.h"
+#include "ComboPassThroughAction.h"
 #include "MacroAction.h"
 #include "MouseMoveAction.h"
 #include "Output.h"
@@ -205,14 +206,22 @@ void G13::parse_bindings_from_stream(std::istream& stream) {
                 if (!std::getline(ss, type, ',')) continue;
                 type = trim_string(type);
 
-                if (type == "p") { 
+                if (type == "p") {
                     std::string keytype_str;
                     if (!std::getline(ss, keytype_str, ',')) continue;
                     keytype_str = trim_string(keytype_str);
                     if (keytype_str.rfind("k.", 0) == 0) {
-                        int keycode = std::stoi(keytype_str.substr(2));
-                        if (gKey >= 0 && gKey < G13_NUM_KEYS) {
-                             actions[gKey] = std::make_unique<PassThroughAction>(keycode);
+                        std::string codes_str = keytype_str.substr(2);
+                        if (gKey < 0 || gKey >= G13_NUM_KEYS) continue;
+                        if (codes_str.find('+') != std::string::npos) {
+                            std::vector<int> codes = parse_plus_list(codes_str);
+                            if (codes.size() > 1) {
+                                actions[gKey] = std::make_unique<ComboPassThroughAction>(codes);
+                            } else if (codes.size() == 1) {
+                                actions[gKey] = std::make_unique<PassThroughAction>(codes[0]);
+                            }
+                        } else {
+                            actions[gKey] = std::make_unique<PassThroughAction>(std::stoi(codes_str));
                         }
                     }
                 }

--- a/g13-driver/src/cpp/G13.cpp
+++ b/g13-driver/src/cpp/G13.cpp
@@ -244,6 +244,10 @@ void G13::parse_bindings_from_stream(std::istream& stream) {
 }
 
 void G13::loadBindings() {
+    // Release anything held before rebinding, so no key survives a profile switch pressed.
+    for (auto& action : actions) {
+        if (action) action->set(0);
+    }
     stick_mouse_disengage();
     stick_mode = STICK_KEYS;
     stick_speed = 8;

--- a/g13-driver/src/cpp/G13.cpp
+++ b/g13-driver/src/cpp/G13.cpp
@@ -326,6 +326,13 @@ G20=p,k.50
         parse_bindings_from_stream(file);
         file.close();
     }
+
+    if (!profile_name.empty()) {
+        clear_lcd_buffer();
+        write_text(2, 16, "Profile:");
+        write_text(2, 28, profile_name);
+        write_lcd();
+    }
 }
 
 void G13::setColor(int red, int green, int blue) {

--- a/g13-driver/src/cpp/G13.h
+++ b/g13-driver/src/cpp/G13.h
@@ -34,6 +34,8 @@ private:
     int                   stick_center_x;
     int                   stick_center_y;
     bool                  stick_centered;
+    int                   stick_acc_x;
+    int                   stick_acc_y;
     std::string           profile_name;
     int                   bindings;
 

--- a/g13-driver/src/cpp/G13.h
+++ b/g13-driver/src/cpp/G13.h
@@ -31,6 +31,9 @@ private:
     bool                  stick_engaged;
     int                   stick_last_x;
     int                   stick_last_y;
+    int                   stick_center_x;
+    int                   stick_center_y;
+    bool                  stick_centered;
     std::string           profile_name;
     int                   bindings;
 

--- a/g13-driver/src/cpp/G13.h
+++ b/g13-driver/src/cpp/G13.h
@@ -24,9 +24,18 @@ private:
     int                   loaded;        
     volatile int          keepGoing;     
 
-    stick_mode_t          stick_mode;    
-    int                   stick_keys[4];   
-    int                   bindings;      
+    stick_mode_t          stick_mode;
+    int                   stick_keys[4];
+    int                   stick_speed;
+    std::vector<int>      stick_hold;
+    bool                  stick_engaged;
+    int                   stick_last_x;
+    int                   stick_last_y;
+    std::string           profile_name;
+    int                   bindings;
+
+    void stick_mouse_tick();
+    void stick_mouse_disengage();
 
     unsigned char lcd_buffer[G13_LCD_BUFFER_SIZE];
 

--- a/g13-driver/src/cpp/MouseMoveAction.cpp
+++ b/g13-driver/src/cpp/MouseMoveAction.cpp
@@ -1,0 +1,64 @@
+#include <linux/uinput.h>
+#include <sstream>
+#include <chrono>
+#include <syslog.h>
+
+#include "MouseMoveAction.h"
+#include "Output.h"
+
+std::vector<int> parse_plus_list(const std::string& value) {
+    std::vector<int> codes;
+    std::stringstream ss(value);
+    std::string part;
+    while (std::getline(ss, part, '+')) {
+        try {
+            codes.push_back(std::stoi(part));
+        } catch (...) {
+            syslog(LOG_WARNING, "parse_plus_list: ignoring invalid code '%s'", part.c_str());
+        }
+    }
+    return codes;
+}
+
+MouseMoveAction::MouseMoveAction(int dx, int dy, std::vector<int> hold)
+    : dx(dx), dy(dy), hold(std::move(hold)), stop_flag(false) {
+}
+
+MouseMoveAction::~MouseMoveAction() {
+    stop_flag = true;
+    if (mover.joinable()) {
+        mover.join();
+    }
+}
+
+void MouseMoveAction::move_loop() {
+    while (!stop_flag) {
+        UInput::send_event(EV_REL, REL_X, dx);
+        UInput::send_event(EV_REL, REL_Y, dy);
+        UInput::send_event(EV_SYN, SYN_REPORT, 0);
+        std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    }
+}
+
+void MouseMoveAction::key_down() {
+    if (mover.joinable()) {
+        mover.join();
+    }
+    for (int code : hold) {
+        UInput::send_event(EV_KEY, code, 1);
+    }
+    UInput::send_event(EV_SYN, SYN_REPORT, 0);
+    stop_flag = false;
+    mover = std::thread(&MouseMoveAction::move_loop, this);
+}
+
+void MouseMoveAction::key_up() {
+    stop_flag = true;
+    if (mover.joinable()) {
+        mover.join();
+    }
+    for (auto it = hold.rbegin(); it != hold.rend(); ++it) {
+        UInput::send_event(EV_KEY, *it, 0);
+    }
+    UInput::send_event(EV_SYN, SYN_REPORT, 0);
+}

--- a/g13-driver/src/cpp/MouseMoveAction.h
+++ b/g13-driver/src/cpp/MouseMoveAction.h
@@ -1,0 +1,38 @@
+#ifndef __MOUSE_MOVE_ACTION_H__
+#define __MOUSE_MOVE_ACTION_H__
+
+#include <vector>
+#include <string>
+#include <thread>
+#include <atomic>
+
+#include "G13Action.h"
+
+// Parses "42+274" into {42, 274}. Invalid segments are skipped.
+std::vector<int> parse_plus_list(const std::string& value);
+
+/**
+ * @class MouseMoveAction
+ * @brief While the key is held, holds a set of keys/buttons and emits
+ *        relative mouse motion (dx, dy) every 10 ms. Used for camera pan.
+ */
+class MouseMoveAction : public G13Action {
+private:
+    int dx;
+    int dy;
+    std::vector<int> hold;
+    std::thread mover;
+    std::atomic<bool> stop_flag;
+
+    void move_loop();
+
+protected:
+    void key_down() override;
+    void key_up() override;
+
+public:
+    MouseMoveAction(int dx, int dy, std::vector<int> hold);
+    ~MouseMoveAction() override;
+};
+
+#endif

--- a/g13-driver/src/cpp/Output.cpp
+++ b/g13-driver/src/cpp/Output.cpp
@@ -124,6 +124,11 @@ bool UInput::create_uinput() {
 	ioctl(file, UI_SET_EVBIT, EV_REL);
 	ioctl(file, UI_SET_RELBIT, REL_X);
 	ioctl(file, UI_SET_RELBIT, REL_Y);
+	// Advertise wheels so libinput treats this as a normal mouse; without
+	// them it enables middle-button scroll emulation on wheel-less mice,
+	// turning MMB-held stick motion into scroll events instead of a drag.
+	ioctl(file, UI_SET_RELBIT, REL_WHEEL);
+	ioctl(file, UI_SET_RELBIT, REL_HWHEEL);
 
 	// Write configuration
 	int retcode = write(file, &uinp, sizeof(uinp));

--- a/g13-driver/src/cpp/Output.cpp
+++ b/g13-driver/src/cpp/Output.cpp
@@ -117,6 +117,14 @@ bool UInput::create_uinput() {
 		ioctl(file, UI_SET_KEYBIT, i);
 	ioctl(file, UI_SET_KEYBIT, BTN_THUMB);
 
+	// Mouse capability: buttons + relative motion (orbit/pan emulation)
+	ioctl(file, UI_SET_KEYBIT, BTN_LEFT);
+	ioctl(file, UI_SET_KEYBIT, BTN_RIGHT);
+	ioctl(file, UI_SET_KEYBIT, BTN_MIDDLE);
+	ioctl(file, UI_SET_EVBIT, EV_REL);
+	ioctl(file, UI_SET_RELBIT, REL_X);
+	ioctl(file, UI_SET_RELBIT, REL_Y);
+
 	// Write configuration
 	int retcode = write(file, &uinp, sizeof(uinp));
 	if (retcode < 0) {


### PR DESCRIPTION
This series adds mouse-emulation features and several robustness fixes to the C++ driver, developed and daily-driven on a G13 under Fedora (KDE Wayland) — primarily to use the G13 for CAD work (Fusion 360 orbit/pan) and gaming.

## Features

- **Mouse capability on the uinput device**: advertises `EV_REL` + `BTN_LEFT/RIGHT/MIDDLE`, plus `REL_WHEEL/REL_HWHEEL` — the wheels matter because libinput otherwise applies middle-button scroll emulation to a wheel-less device and swallows MMB-drag gestures (CAD orbit).
- **`mp` binding type** (`mp,<dx>,<dy>[,<hold+list>]`): a G-key emits relative mouse motion while held, optionally holding mouse buttons/keys — e.g. pan keys for CAD.
- **Stick mouse mode** (per-profile `stick_mode=mouse`, `stick_speed=N`, `stick_hold=42+274`): the stick moves the pointer while holding a configurable chord (e.g. Shift+MMB = Fusion 360 orbit). Includes sub-pixel remainder accumulation so low speeds stay smooth, and stick-neutral auto-calibration from the first USB report to eliminate drift.
- **Combo passthrough bindings** (`p,k.29+46`): a G-key holds a full chord (Ctrl+C, Shift+MMB, …) for as long as it's pressed — key-down in listed order, key-up in reverse, so key repeat behaves like the real chord.
- **Profile name on the LCD** (`name=` property) shown at profile load, and the active profile number written to `$XDG_RUNTIME_DIR/g13-profile` for external status tools.

## Fixes

- **Stuck-key fix**: all held keys are released before bindings reload, so switching profiles mid-press can no longer leave a key latched.

## Compatibility

All existing bindings files parse unchanged — every new property/syntax is additive, and the single-key `p,k.<code>` path is untouched. The Java GUI is not modified; it simply won't emit the new syntaxes.

Each commit is self-contained and builds; happy to split this into smaller PRs, drop any part, or adjust style if you'd prefer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)